### PR TITLE
Fix / 프로그래스바, 다크테마 2번 클릭 or 라이트테마 2번 클릭 후 이전에 올렸던 같은 이미지를 업로드 할 시 적용이…

### DIFF
--- a/src/components/adminSide/myadmin/theme/Theme.jsx
+++ b/src/components/adminSide/myadmin/theme/Theme.jsx
@@ -26,20 +26,6 @@ const Theme = () => {
   const [loading, setLoading] = useState(false); // 이미지 업로드 진행상태 저장
   const [progress, setProgress] = useState(0); // 프로그래스바 0 ~ 100% 진행률 업데이트
 
-  // useEffect(() => {
-  //   let intervalId;
-  //   if (loading) {
-  //     intervalId = setInterval(() => {
-  //       setProgress((prevProgress) =>
-  //         prevProgress < 100
-  //           ? prevProgress + 100 / (imageUploadTime / 3000)
-  //           : prevProgress,
-  //       );
-  //     }, imageUploadTime / 100);
-  //   }
-  //   return () => clearInterval(intervalId);
-  // }, [loading]);
-
   useEffect(() => {
     let intervalId;
 
@@ -282,11 +268,6 @@ const Theme = () => {
             {loading ? (
               <Progress percent={Math.round(progress)} status="active" />
             ) : (
-              // <Progress
-              //   type="line"
-              //   percent={100}
-              //   format={() => '이미지 파일 업로드 중...'}
-              // />
               <button
                 style={{
                   width: '100%',
@@ -299,17 +280,6 @@ const Theme = () => {
                 적용하기
               </button>
             )}
-            {/* <button
-              style={{
-                width: '100%',
-                border: '1px solid #000',
-                borderRadius: '5px',
-              }}
-              disabled={loading}
-              onClick={handleApplyClick}
-            >
-              적용하기
-            </button> */}
           </Col>
         </Row>
       </Modal>


### PR DESCRIPTION
- 이미지 압축시 업로드하고 저장되는 부분에서 딜레이가 생기는 현상 임시조치로 antd 프로그래스바로 setInterval로 시간을 넣어준 뒤 100%가 되면 버튼이 생기게 처리
- 다크테마 2번 클릭 or 라이트테마 2번 클릭 후 이전에 올렸던 같은 이미지를 업로드 할 시 적용이 되지 않는 현상